### PR TITLE
Add feedback form and re-generation option

### DIFF
--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -103,6 +103,7 @@ def document_to_podcast_script(
     title: str = "AI in Action",
     voice_1: str = "Andrew",
     voice_2: str = "Emma",
+    feedback: str = None,
 ) -> PodcastScriptResponse:
     """Get LLM response."""
 
@@ -120,6 +121,10 @@ def document_to_podcast_script(
             azure_ad_token_provider=get_token_provider(),
         )
 
+    user_content = f"<title>{title}</title><documents><document>{document}</document></documents>"
+    if feedback:
+        user_content += f"\n\nUser Feedback: {feedback}"
+
     chat_completion = client.chat.completions.create(
         messages=[
             {
@@ -130,7 +135,7 @@ def document_to_podcast_script(
             # https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter?tabs=warning%2Cindirect%2Cpython-new#embedding-documents-in-your-prompt
             {
                 "role": "user",
-                "content": f"<title>{title}</title><documents><document>{document}</document></documents>",
+                "content": user_content,
             },
         ],
         model=os.getenv("AZURE_OPENAI_MODEL_DEPLOYMENT", "gpt-4o"),


### PR DESCRIPTION
Related to #8

Add feedback and re-generation functionality for podcast script generation.

* **app/app.py**
  - Add a feedback form after the podcast script is generated.
  - Include a text area for user comments and a button to regenerate the podcast.
  - Update the user interface to display the regenerated podcast script and audio.

* **app/utils/llm.py**
  - Update the `document_to_podcast_script` function to handle feedback and re-generate the podcast script based on user input.
  - Modify the user content to include feedback if provided.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/iMicknl/azure-podcast-generator/pull/17?shareId=01ce70df-0dae-4e99-8e20-1e72f535c7e7).