### PR TITLE
Adding slider for max tokens for generating the podcast script

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -87,11 +87,11 @@ with form_container.expander("Advanced options", expanded=False):
     max_tokens = st.slider(
         "Max Tokens",
         min_value=1000,
-        max_value=8000,
-        value=5000,
+        max_value=32000,
+        value=8000,
         step=500,
+        help="Select the maximum number of tokens to be used for generating the podcast script. Adjust this according to your OpenAI quota.",
     )
-
 # Submit button
 generate_podcast = form_container.button(
     "Generate Podcast", type="primary", disabled=not uploaded_file

--- a/app/app.py
+++ b/app/app.py
@@ -83,6 +83,15 @@ with form_container.expander("Advanced options", expanded=False):
         else 1,
     )
 
+    # Max tokens slider
+    max_tokens = st.slider(
+        "Max Tokens",
+        min_value=1000,
+        max_value=8000,
+        value=5000,
+        step=500,
+    )
+
 # Submit button
 generate_podcast = form_container.button(
     "Generate Podcast", type="primary", disabled=not uploaded_file
@@ -131,6 +140,7 @@ if uploaded_file and generate_podcast:
             title=podcast_title,
             voice_1=voice_1,
             voice_2=voice_2,
+            max_tokens=max_tokens,
         )
 
         podcast_script = podcast_response.podcast["script"]

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -103,7 +103,7 @@ def document_to_podcast_script(
     title: str = "AI in Action",
     voice_1: str = "Andrew",
     voice_2: str = "Emma",
-    max_tokens: int = 5000,
+    max_tokens: int = 8000,
 ) -> PodcastScriptResponse:
     """Get LLM response."""
 

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -103,6 +103,7 @@ def document_to_podcast_script(
     title: str = "AI in Action",
     voice_1: str = "Andrew",
     voice_2: str = "Emma",
+    max_tokens: int = 5000,
 ) -> PodcastScriptResponse:
     """Get LLM response."""
 
@@ -136,7 +137,7 @@ def document_to_podcast_script(
         model=os.getenv("AZURE_OPENAI_MODEL_DEPLOYMENT", "gpt-4o"),
         temperature=0.7,
         response_format={"type": "json_schema", "json_schema": JSON_SCHEMA},
-        max_tokens=8000,
+        max_tokens=max_tokens,
     )
 
     message = chat_completion.choices[0].message.content


### PR DESCRIPTION
I ran into the issue where 8000 token was too much for my current OpenAI implementation. Instead of having to adjust the `max_token` in code, I added a simple streamlit slider that makes it adjustable.

It's located under the voice selection in `Advanced Options`

![afbeelding](https://github.com/user-attachments/assets/5e0ffade-fa75-4427-9311-9b9bd1483cc2)
