### PR TITLE
Increase OpenAI deployment quota to 30K TPM and migrate to DataZoneStandard deployment

### DIFF
--- a/infra/modules/cognitive.bicep
+++ b/infra/modules/cognitive.bicep
@@ -26,8 +26,8 @@ resource gpt4oDeployment 'Microsoft.CognitiveServices/accounts/deployments@2023-
   parent: openAi
   name: modelDeploymentName
   sku: {
-    name: 'Standard'
-    capacity: 1
+    name: 'DataZoneStandard'
+    capacity: 30
   }
   properties: {
     model: {


### PR DESCRIPTION
This pull request includes changes to the `infra/modules/cognitive.bicep` file to update the deployment configuration for a specific resource. The most important change involves modifying the SKU and capacity settings for the deployment.

Deployment configuration update:

* [`infra/modules/cognitive.bicep`](diffhunk://#diff-e16b791e836af8bebdca09d7d0d567776f5f326214efaa010c9989b83bff254eL29-R30): Changed the SKU name from 'Standard' to 'DataZoneStandard' and increased the capacity from 1 to 30 for the `gpt4oDeployment` resource.